### PR TITLE
Silence variable warnings

### DIFF
--- a/BIR-transformations/copy-function.lisp
+++ b/BIR-transformations/copy-function.lisp
@@ -194,7 +194,6 @@
 
 (defmethod clone-initargs append
     ((instruction cleavir-bir:instruction) stack map)
-  (declare (ignore stack))
   (list
    :inputs (mapcar (input-copier map) (cleavir-bir:inputs instruction))
    :outputs (mapcar (output-copier stack map)

--- a/BIR-transformations/meta-evaluate.lisp
+++ b/BIR-transformations/meta-evaluate.lisp
@@ -11,7 +11,7 @@
   ;; just two or three passes. We repeat on the module level so that
   ;; types are more likely to get propagated interprocedurally.
   (dotimes (repeat 3)
-    (declare (ignore repeat))
+    (declare (ignorable repeat))
     (cleavir-bir:do-functions (function module)
       (meta-evaluate-function function system)
       (cleavir-bir:compute-iblock-flow-order function))))

--- a/Environment/type-information.lisp
+++ b/Environment/type-information.lisp
@@ -130,6 +130,7 @@
 
 (defmethod parse-expanded-type-specifier
     ((type-specifier (eql 'cl:function)) environment system)
+  (declare (cl:ignore environment))
   (cleavir-ctype:function-top system))
 
 (defmethod parse-expanded-type-specifier


### PR DESCRIPTION
* Two variables are used, although declared ignore
  * `stack` is used
  * `repeat` as iteration variable is incremented
*  `environment` is not used

* to test recompiled clasp and run regression and ansi-tests