### PR TITLE
More (declare (ignore ..)) to silence last compiler warnings

### DIFF
--- a/BIR-transformations/eliminate-catches.lisp
+++ b/BIR-transformations/eliminate-catches.lisp
@@ -8,6 +8,7 @@
         (fore (cleavir-bir:iblock catch))
         (normal-next (first (cleavir-bir:next catch)))
         (other-next (rest (cleavir-bir:next catch))))
+    (declare (ignore other-next))
     (cleavir-set:doset (s (cleavir-bir:scope catch))
       (setf (cleavir-bir:dynamic-environment s) nde))
     ;; Replace the instruction

--- a/BIR-transformations/meta-evaluate.lisp
+++ b/BIR-transformations/meta-evaluate.lisp
@@ -426,6 +426,7 @@
           (derive-type-for-linear-datum out type system))))))
 
 (defmethod meta-evaluate-instruction ((instruction cleavir-bir:leti) system)
+  (declare (ignore system))
   (let ((variable (cleavir-bir:output instruction)))
     (when variable
       (or (substitute-single-read-variable-if-possible variable)

--- a/Environment/default-info-methods.lisp
+++ b/Environment/default-info-methods.lisp
@@ -658,7 +658,7 @@
 ;;; This method is called when the environment is the global
 ;;; environment.
 (defmethod function-inline-expansion (environment defining-info)
-  (declare (cl:ignore environment))
+  (declare (cl:ignore environment defining-info))
   nil)
 
 ;;; This method is called when the entry is not related to the


### PR DESCRIPTION
With these changes I no longer see compiler warnings for ../contrib/Cleavir/.

Tested with regression and ansi-tests

I also similar independent made PRs for 
* Eclector and (in master, will check how to easiest bring that to clasp)
* Concrete-Syntax-Tree 