### PR TITLE
Treat compiler warnings

### DIFF
--- a/AST-to-BIR/compile-multiple-value-related-asts.lisp
+++ b/AST-to-BIR/compile-multiple-value-related-asts.lisp
@@ -1,6 +1,7 @@
 (in-package #:cleavir-ast-to-bir)
 
-(defun compile-m-v-p1-save (inserter system mv form-asts))
+(defun compile-m-v-p1-save (inserter system mv form-asts)
+  (declare (ignore inserter system mv form-asts)))
 
 (defmethod compile-ast ((ast ast:multiple-value-prog1-ast) inserter system)
   (with-compiled-ast (rv (ast:first-form-ast ast) inserter system)

--- a/Abstract-syntax-tree/general-purpose-asts.lisp
+++ b/Abstract-syntax-tree/general-purpose-asts.lisp
@@ -866,7 +866,8 @@
 (defun make-multiple-value-call-ast
     (function-form-ast form-asts
      &key origin (policy *policy*)
-       (attributes (cleavir-attributes:default-attributes)))
+          (attributes (cleavir-attributes:default-attributes)))
+  (declare (cl:ignore attributes))
   (make-instance 'multiple-value-call-ast
     :origin origin :policy policy
     :function-form-ast function-form-ast :form-asts form-asts))

--- a/Attributes/attributes.lisp
+++ b/Attributes/attributes.lisp
@@ -38,8 +38,9 @@
 (defgeneric has-flag-p (attributes flag-name))
 
 (defmethod has-flag-p ((attributes null) flag-name)
-  (declare (ignore has-flag-p))
+  (declare (ignore flag-name))
   nil)
+
 (defmethod has-flag-p ((attributes attributes) flag-name)
   (%has-flag-p (flags attributes) flag-name))
 

--- a/BIR-transformations/eliminate-catches.lisp
+++ b/BIR-transformations/eliminate-catches.lisp
@@ -3,8 +3,7 @@
 (defun catch-eliminable-p (catch) (set:empty-set-p (bir:unwinds catch)))
 
 (defun eliminate-catch (catch)
-  (let ((nde (bir:dynamic-environment catch))
-        (fore (bir:iblock catch))
+  (let ((fore (bir:iblock catch))
         (normal-next (first (bir:next catch))))
     ;; Replace the instruction
     (bir:replace-terminator

--- a/BIR-transformations/interpolate-function.lisp
+++ b/BIR-transformations/interpolate-function.lisp
@@ -261,6 +261,7 @@
 ;;; When the function does return normally, wire the return value of
 ;;; the function into the common ``transitive'' use of the local calls.
 (defun contify (function local-calls return-point common-use common-dynenv target-owner)
+  (declare (ignore common-use))
   (let* ((returni (bir:returni function))
          ;; If there is exactly one outside call to the function, it may be in
          ;; the middle of a block, and have its output used somewhere other

--- a/BIR-transformations/meta-evaluate.lisp
+++ b/BIR-transformations/meta-evaluate.lisp
@@ -820,7 +820,7 @@
                                 system)
             system))
           (t
-           (let ((argstype
+           (let* ((argstype
                    (ctype:values (loop for arg in (rest (bir:inputs inst))
                                        for ct = (bir:ctype arg)
                                        collect (ctype:primary ct system))

--- a/BIR/graph-modifications.lisp
+++ b/BIR/graph-modifications.lisp
@@ -10,7 +10,6 @@
 
 (defgeneric remove-use (datum use))
 (defmethod remove-use ((datum linear-datum) use)
-  (declare (cl:ignore use))
   (when (eql (%use datum) use)
     (setf (%use datum) nil)))
 (defmethod remove-use ((datum variable) use)

--- a/Environment/type-information.lisp
+++ b/Environment/type-information.lisp
@@ -169,6 +169,7 @@
   (parse-array-type-specifier 'array 'bit '(*) env sys))
 
 (defmethod parse-expanded-type-specifier ((ts (eql 'cl:boolean)) env sys)
+  (declare (cl:ignore env))
   (cleavir-ctype:member sys nil t))
 
 (defmethod parse-expanded-type-specifier ((ts (eql 'cl:character)) env sys)
@@ -200,12 +201,14 @@
     double-float long-float))
 
 (defmethod parse-expanded-type-specifier ((ts (eql 'cl:extended-char)) env sys)
+  (declare (cl:ignore env))
   (cleavir-ctype:conjoin sys
                          (cleavir-ctype:character sys)
                          (cleavir-ctype:negate (cleavir-ctype:base-char sys)
                                                sys)))
 
 (defmethod parse-expanded-type-specifier ((ts (eql 'cl:fixnum)) env sys)
+  (declare (cl:ignore env))
   (cleavir-ctype:fixnum sys))
 
 (defmethod parse-expanded-type-specifier
@@ -418,6 +421,7 @@
 
 (defmethod parse-compound-type-specifier ((head (eql 'signed-byte))
                                           rest env sys)
+  (declare (cl:ignore env))
   (destructuring-bind (&optional (bits '*)) rest
     (if (eq bits '*)
         (cleavir-ctype:range 'integer '* '* sys)
@@ -452,6 +456,7 @@
 
 (defmethod parse-compound-type-specifier ((head (eql 'unsigned-byte))
                                           rest env sys)
+  (declare (cl:ignore env))
   (destructuring-bind (&optional (bits '*)) rest
     (cleavir-ctype:range 'integer 0 (if (eq bits '*) '* (1- (ash 1 bits)))
                          sys)))


### PR DESCRIPTION
* BIR-transformations/meta-evaluate.lisp is real error with reference to `argstype`, changed to let
* BIR/graph-modifications.lisp had an outdated `(declare (cl:ignore use))`
* all other are now silenced `style-warnings`