### PR TITLE
Add missing format paramter in (eq (iblock instruction) *verifying-iblock*)

### DIFF
--- a/BIR/verify.lisp
+++ b/BIR/verify.lisp
@@ -75,7 +75,7 @@
   ;; iblock is correct
   (test (eq (iblock instruction) *verifying-iblock*)
         "Instruction ~a's iblock ~a does not match its presence in ~a"
-        instruction (iblock instruction) *verifying-iblock*)
+        instruction instruction (iblock instruction) *verifying-iblock*)
   (verify-inputs instruction)
   (let ((inputs (inputs instruction)))
     (test (or (null inputs) (not (set:presentp inputs *seen-lists*)))


### PR DESCRIPTION
to reproduce in clasp:

```lisp
(LAMBDA (C)
  (DECLARE (NOTINLINE =))
    (LOOP FOR LV1 BELOW 2 COUNT (AND (= 13250 LV1) C)))
````

gives a compiler error in verify - another problem - but also errors while printing the error with:

```lisp
Error in format: No more arguments.
  Instruction ~a's iblock ~a does not match its presence in ~a
                                                             ^
   [Condition of type CORE::FORMAT-ERROR]
````