### PR TITLE
BIR transformations: Separate local call pass from interpolation

### DIFF
--- a/BIR-transformations/interpolate-function.lisp
+++ b/BIR-transformations/interpolate-function.lisp
@@ -361,3 +361,19 @@
             ;; itself.
             (unless (eq function target-owner)
               (contify function local-calls return-point common-use common-dynenv target-owner))))))))
+
+(defun interpolate-module-calls (module)
+  ;; Since contification depends on all non-tail local calls being in
+  ;; the same function, it may be the case that contifying triggers
+  ;; more contification. Therefore, we do a second pass/fixpoint loop
+  ;; to make sure everything gets contified. This also ensures that we
+  ;; contify deterministically, since the result of a single pass
+  ;; depends on the order of iteration over the set of functions in
+  ;; the module.
+  (let ((did-something nil))
+    (loop do (let ((changed nil))
+               (bir:do-functions (function module)
+                 (when (maybe-interpolate function)
+                   (setq changed t)))
+               (setq did-something changed))
+          while did-something)))

--- a/BIR-transformations/packages.lisp
+++ b/BIR-transformations/packages.lisp
@@ -9,7 +9,8 @@
   (:export #:module-eliminate-come-froms #:eliminate-come-froms)
   (:export #:module-optimize-variables #:function-optimize-variables)
   (:export #:simple-unwinding-p #:simple-dynenv-p)
-  (:export #:find-module-local-calls #:maybe-interpolate)
+  (:export #:find-module-local-calls
+           #:interpolate-module-calls #:maybe-interpolate)
   (:export #:determine-function-environments)
   (:export #:determine-closure-extents)
   (:export #:determine-variable-extents)


### PR DESCRIPTION
I'm trying to move towards a model where analysis passes handle local calls just fine, in which case we don't need the complication of actual interpolation until later during code generation. We'll see how that works out.

Calling the interpolator right after the local call finder will be slightly dumber, in the interim, because the local call finder is itself improved by interpolation. But I think that can be fixed, and in the meantime a client could just call them both repeatedly.